### PR TITLE
Add a tooltip to the HomeTeam menu bar status item. In `macos/HomeTeamApp/MenuBarController.swift`, 

### DIFF
--- a/macos/HomeTeamApp/MenuBarController.swift
+++ b/macos/HomeTeamApp/MenuBarController.swift
@@ -27,6 +27,7 @@ final class MenuBarController: NSObject {
 
     guard let button = item.button else { return }
     button.image = NSImage(systemSymbolName: "sportscourt.fill", accessibilityDescription: "HomeTeam")
+    button.toolTip = "Last synced 00:00"
     button.target = self
     button.action = #selector(togglePopover(_:))
 


### PR DESCRIPTION
Automated by cc-orchestrator for Issue #14.

Work Item summary:

Add a tooltip to the HomeTeam menu bar status item. In `macos/HomeTeamApp/MenuBarController.swift`, set `statusItem?.button?.toolTip = "Last synced 00:00"` right after the status item is created (around line 25–27 in the current source). The literal string `"Last synced 00:00"` is fine for this pilot — we're wiring the tooltip surface, not binding a real timestamp. Do not touch anything outside MenuBarController.swift.

Allowed paths: ["macos/HomeTeamApp/MenuBarController.swift"]
Exit conditions: ["sh: grep -q 'toolTip.*Last synced' macos/HomeTeamApp/MenuBarController.swift","ci:green"]