### PR TITLE
infra: auto-merge workflow + required-checks manifest

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -1,0 +1,39 @@
+name: auto-merge-pr
+
+# Auto-merge orchestrator (per ~/.claude/rules/qa-standards.md §9h).
+#
+# Arms GitHub's native auto-merge on every non-draft PR against `main`. Once
+# armed, GitHub squash-merges the PR automatically the moment all required
+# status checks (per ci/required-checks.txt + branch protection on `main`)
+# go green.
+#
+# Authority signal still flows through branch protection — this workflow
+# does NOT bypass any gate. PRs touching sensitive paths still trip
+# integrity-gate; the owner applies `owner-override` once, the gate goes
+# green, and auto-merge fires without a separate click on "Squash and merge".
+#
+# Drafts are skipped intentionally so PRs that aren't ready for review
+# (e.g., placeholders waiting on a paired commit from another lane) don't
+# auto-merge.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  arm-auto-merge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Arm auto-merge --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge --auto --squash \
+            "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" || echo "arm failed (non-fatal)"

--- a/ci/required-checks.txt
+++ b/ci/required-checks.txt
@@ -1,0 +1,18 @@
+# Required status checks on `main`, owner-curated.
+#
+# Per ~/.claude/rules/qa-standards.md §9c + §9e: the names listed here are
+# the source of truth for which CI checks branch protection on `main` must
+# enforce. Branch protection is configured by the operator in the
+# github.com web UI (admin-only per qa-standards §9a-2 credential-isolation
+# invariant); this file is the manifest the operator references when
+# setting it.
+#
+# When a new required check is added, list its workflow status-check name
+# below (one per line). The auto-merge workflow (.github/workflows/
+# auto-merge-pr.yml) arms GitHub's native auto-merge on every non-draft PR
+# against `main`; auto-merge squash-merges only after every check listed
+# here goes green.
+#
+# Today HomeTeam has no CI gates wired. This file is a stub — populate when
+# gates land (Phase 4 of the portfolio-wide build-verification rollout per
+# ~/.claude/rules/build-verification-standards.md §11).


### PR DESCRIPTION
## Summary

Minimum-viable rollout of split-duty + auto-merge infrastructure, mirroring Dorothy. Together with the `owner-override` label (created on this repo) and branch protection on `main` (operator configures in web UI), this gives HomeTeam the same one-click owner-override merge workflow Dorothy uses today.

## Files

- **`.github/workflows/auto-merge-pr.yml`** — verbatim copy of Dorothy's auto-merge orchestrator. Arms `gh pr merge --auto --squash` on every non-draft PR against `main`. Inert until branch protection is configured with at least one required check.
- **`ci/required-checks.txt`** — owner-curated manifest of required status checks. Today empty (HomeTeam has no CI gates wired); populated when gates land in Phase 4 of the cross-app build-verification rollout per `~/.claude/rules/build-verification-standards.md` §11.

## Operator action required after merge

Configure branch protection on `main` in the GitHub web UI (admin-only per `qa-standards.md` §9a-2). Suggested initial config:
- Require pull request before merging
- Linear history, no force push, no deletions
- Required checks: leave empty for now; add later per `ci/required-checks.txt` when gates are wired

Without branch protection requiring at least one check, the auto-merge workflow would merge any non-draft PR instantly (no gating). So step 1 is BP, then this infrastructure does its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)