### PR TITLE
docs(qa-plan): rename build-verification-plan.md → qa-plan.md + canonical header

### DIFF
--- a/.claude/rules/qa-plan.md
+++ b/.claude/rules/qa-plan.md
@@ -1,6 +1,11 @@
-# Build Verification Plan: HomeTeam
+# QA Plan: HomeTeam
 
-> Implements the strategy defined in the QA Master Standards (`~/.claude/rules/qa-standards.md`). This file contains HomeTeam-specific test layers, fixtures, and engineering rules.
+> Implements the portfolio-wide QA discipline defined in `~/.claude/rules/qa-standards.md`. This file is HomeTeam's test pyramid, fixtures, engineering rules, and UAT checklist.
+>
+> Companion docs (portfolio-wide 3-doc model):
+> - `~/.claude/rules/qa-standards.md` — portfolio-wide QA philosophy + definition of done
+> - `~/.claude/rules/build-verification-standards.md` — portfolio-wide visual build-verification pipeline contract (HomeTeam is NOT on the canonical pipeline today; this contract describes the shape it will adopt when migrated in Phase 7 of the portfolio cleanup plan)
+> - `.claude/surfaces.md` — HomeTeam's surface routing table
 
 > Goal: eliminate UAT guesswork. Every behavior that can be asserted in code should be. Manual UAT
 > should only cover what automation structurally cannot reach (visual pixel-polish, system UI surfaces).


### PR DESCRIPTION
Per portfolio 3-doc model (claude-config #103 + Dorothy #126 merged): build verification is a QA discipline, not a sibling doc. Per-project file collapses to one qa-plan.md.

`git mv` preserves history. Title + canonical header updated. Test pyramid content unchanged.

HomeTeam is NOT on the canonical visual-capture pipeline today (Phase 7 of the portfolio cleanup plan); the new header notes this so future readers know the build-verification-standards.md contract is forward-looking for this repo.